### PR TITLE
ci: Enable CI build events forwarding

### DIFF
--- a/tools/ci/bazel.rc
+++ b/tools/ci/bazel.rc
@@ -14,6 +14,16 @@ test --verbose_failures
 build --action_env=CC=clang
 build --announce_rc=yes
 
+# BES UI
+build --bes_results_url=https://app.buildbuddy.io/invocation/
+build --bes_backend=grpcs://events.buildbuddy.io:1986
+build --remote_cache=grpcs://cache.buildbuddy.io:1986
+build --noremote_upload_local_results
+test --bes_results_url=https://app.buildbuddy.io/invocation/
+test --bes_backend=grpcs://events.buildbuddy.io:1986
+test --remote_cache=grpcs://cache.buildbuddy.io:1986
+test --noremote_upload_local_results
+
 # UI config
 build --color=yes
 build --curses=no


### PR DESCRIPTION
These changes enabled sending build events to [BuildBuddy](https://app.buildbuddy.io/docs/setup) anonymously.