### PR TITLE
renovate: Disable post-upgrade tasks

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,11 +2,5 @@
   extends: ["config:base"],
   ignorePaths: ["third_party/**"],
   labels: ["dependencies"],
-  postUpgradeTasks: {
-    commands: [
-      "./tools/update-deps.sh",
-      "./tools/format.sh",
-    ],
-  },
   schedule: ["every weekend"],
 }


### PR DESCRIPTION
[Post-upgrade tasks](https://docs.renovatebot.com/configuration-options/#postupgradetasks) can only be used on self-hosted Renovate instances.