### PR TITLE
deps: Update deprecated usage of clap::App

### DIFF
--- a/src/rust/hello_world/src/main.rs
+++ b/src/rust/hello_world/src/main.rs
@@ -1,7 +1,7 @@
 extern crate clap;
 
 fn main() {
-    let matches = clap::App::new("hello_world")
+    let matches = clap::Command::new("hello_world")
         .arg(
             clap::Arg::new("name")
                 .long("name")


### PR DESCRIPTION
[`clap::App`](https://docs.rs/clap/3.1.1/clap/struct.App.html) is deprecated since 3.1.0, replaced with `clap::Command`.