### PR TITLE
fix: Formatters location

### DIFF
--- a/tools/format.sh
+++ b/tools/format.sh
@@ -1,36 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-set -x
+AUTOFLAKE="$(bazel run --run_under='echo' //tools/autoflake)"
+GOFMT="$(bazel run --run_under=echo @go_sdk//:bin/gofmt)"
+ISORT="$(bazel run --run_under='echo' //tools/isort)"
+JAVAFORMAT="$(bazel run --run_under='echo' @com_google_google_java_format//:google-java-format)"
+YAPF="$(bazel run --run_under='echo' //tools/yapf)"
 
-bazel build //tools/autoflake
-AUTOFLAKE="./bazel-bin/tools/autoflake/autoflake"
-
-bazel build //tools/isort
-ISORT="./bazel-bin/tools/isort/isort"
-
-bazel build //tools/yapf
-YAPF="./bazel-bin/tools/yapf/yapf"
-
+# We cannot use run_under here because of https://github.com/bazelbuild/rules_foreign_cc/issues/582
 bazel build //tools/uncrustify
-UNCRUSTIFY="./bazel-bin/tools/uncrustify/uncrustify/bin/uncrustify -c tools/uncrustify/uncrustify.cfg --no-backup --replace"
-
-bazel build @com_google_google_java_format//:google-java-format
-JAVAFORMAT="./bazel-bin/external/com_google_google_java_format/google-java-format --aosp --replace"
+UNCRUSTIFY="./bazel-bin/tools/uncrustify/uncrustify/bin/uncrustify"
 
 # C and Cpp
-find . -type f -name '*.c' -print0 | xargs -0 $UNCRUSTIFY
-find . -type f -name '*.cc' -print0 | xargs -0 $UNCRUSTIFY
-find . -type f -name '*.h' -print0 | xargs -0 $UNCRUSTIFY
-find . -type f -name '*.hh' -print0 | xargs -0 $UNCRUSTIFY
+cpp_patterns=('*.c' '*.cc' '*.h' '*.hh')
+for pattern in "${cpp_patterns[@]}"; do
+    find . -type f -name "$pattern" -print0 | xargs -0 "$UNCRUSTIFY" -c tools/uncrustify/uncrustify.cfg --no-backup --replace
+done
 
 # Go
-go fmt ./...
+find . -type f -name '*.go' -print0 | xargs -0 "$GOFMT" -w
 bazel run //:gazelle
 
 # Java
-# FIXME(sb) get google-java-format from WORKSPACE
-find . -type f -name '*.java' -print0 | xargs -0 $JAVAFORMAT
+find . -type f -name '*.java' -print0 | xargs -0 "$JAVAFORMAT" --aosp --replace
 
 # Python
 find . -type f -iname '*.py' -print0 | xargs -0 "$AUTOFLAKE" --in-place --remove-unused-variables
@@ -38,8 +30,7 @@ find . -type f -iname '*.py' -print0 | xargs -0 "$ISORT"
 find . -type f -iname '*.py' -print0 | xargs -0 "$YAPF" -i --no-local-style -p
 
 # Rust
-source $HOME/.cargo/env
-cargo fmt
+bazel run @rules_rust//:rustfmt
 
 # Bazel
 bazel run //:buildifier


### PR DESCRIPTION
Bazel v5 or rules_python changed the location of the python entry_points. This uses `run_under` to find the correct location going forward.
