### PR TITLE
Rust test crate

### DIFF
--- a/src/rust/web/BUILD.bazel
+++ b/src/rust/web/BUILD.bazel
@@ -19,16 +19,8 @@ rust_binary(
 rust_test(
     name = "web_test",
     size = "small",
-    srcs = ["src/main.rs"],
-    compile_data = ["templates/hello.html"],
+    crate = ":web",
     deps = [
-        "//src/rust/web/cargo:askama",
-        "//src/rust/web/cargo:iron",
-        "//src/rust/web/cargo:iron_slog",
         "//src/rust/web/cargo:iron_test",
-        "//src/rust/web/cargo:router",
-        "//src/rust/web/cargo:slog",
-        "//src/rust/web/cargo:slog_async",
-        "//src/rust/web/cargo:slog_term",
     ],
 )


### PR DESCRIPTION
Use the `crate` attribute from `rust_test` instead of copy all the `rust_library` attributes.