### PR TITLE
c++: Add sample gtest test

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,5 @@
+build --cxxopt='-std=c++17'
+
 build --java_runtime_version=remotejdk_11
 build --tool_java_language_version=11
 build --javacopt="--release 11"

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -53,6 +53,21 @@ http_archive(
 )
 
 http_archive(
+    name = "com_google_googletest",
+    sha256 = "5cf189eb6847b4f8fc603a3ffff3b0771c08eec7dd4bd961bfd45477dd13eb73",
+    strip_prefix = "googletest-609281088cfefc76f9d0ce82e1ff6c30cc3591e5",
+    urls = ["https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip"],
+)
+
+http_archive(
+    name = "fmtlib",
+    build_file = "//third_party:cc/fmtlib/BUILD.external",
+    sha256 = "3d794d3cf67633b34b2771eb9f073bde87e846e0d395d254df7b211ef1ec7346",
+    strip_prefix = "fmt-8.1.1",
+    urls = ["https://github.com/fmtlib/fmt/archive/refs/tags/8.1.1.tar.gz"],
+)
+
+http_archive(
     name = "io_bazel_rules_go",
     sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
     urls = ["https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip"],

--- a/src/cpp/hello_world/BUILD.bazel
+++ b/src/cpp/hello_world/BUILD.bazel
@@ -1,12 +1,12 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("//tools/test/binary:binary.bzl", "binary_test")
 
 cc_binary(
     name = "hello_world",
     srcs = ["hello_world.cc"],
     visibility = ["//visibility:public"],
+    deps = ["//src/cpp/hello_world/greet"],
 )
-
-load("//tools/test/binary:binary.bzl", "binary_test")
 
 binary_test(
     name = "hello_world_test",

--- a/src/cpp/hello_world/greet/BUILD.bazel
+++ b/src/cpp/hello_world/greet/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_library(
+    name = "greet",
+    srcs = ["greet.cc"],
+    hdrs = ["greet.h"],
+    visibility = ["//src/cpp/hello_world:__pkg__"],
+    deps = ["@fmtlib//:fmt"],
+)
+
+cc_test(
+    name = "greet_test",
+    size = "small",
+    srcs = ["greet_test.cc"],
+    deps = [
+        ":greet",
+        "@com_google_googletest//:gtest_main",
+    ],
+)

--- a/src/cpp/hello_world/greet/greet.cc
+++ b/src/cpp/hello_world/greet/greet.cc
@@ -1,0 +1,11 @@
+#include "greet.h"
+#include <string>
+#include <fmt/core.h>
+
+namespace greet {
+std::string
+greet(std::string name)
+{
+  return fmt::format("Hello, {}!", name);
+}
+}

--- a/src/cpp/hello_world/greet/greet.h
+++ b/src/cpp/hello_world/greet/greet.h
@@ -1,0 +1,5 @@
+#include <string>
+
+namespace greet {
+std::string greet(std::string name = "World");
+}

--- a/src/cpp/hello_world/greet/greet_test.cc
+++ b/src/cpp/hello_world/greet/greet_test.cc
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+#include "greet.h"
+
+TEST(GreetTest, NameNotProvided) {
+  EXPECT_EQ(greet::greet(), "Hello, World!");
+}
+
+TEST(GreetTest, NameProvided) {
+  EXPECT_EQ(greet::greet("Gtest"), "Hello, Gtest!");
+}

--- a/src/cpp/hello_world/hello_world.cc
+++ b/src/cpp/hello_world/hello_world.cc
@@ -1,5 +1,6 @@
 #include <getopt.h>
 #include <iostream>
+#include "src/cpp/hello_world/greet/greet.h"
 
 int
 main(int argc, char **argv)
@@ -51,5 +52,5 @@ main(int argc, char **argv)
     }
   }
 
-  std::cout << "Hello, " << name << "!" << std::endl;
+  std::cout << greet::greet(name) << std::endl;
 }

--- a/src/python/hello_world/BUILD.bazel
+++ b/src/python/hello_world/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@pypi//:requirements.bzl", "requirement")
+load("//tools/test/binary:binary.bzl", "binary_test")
 
 py_binary(
     name = "hello_world",
@@ -11,8 +12,6 @@ py_binary(
         requirement("markupsafe"),
     ],
 )
-
-load("//tools/test/binary:binary.bzl", "binary_test")
 
 binary_test(
     name = "hello_world_test",

--- a/third_party/cc/fmtlib/BUILD.external
+++ b/third_party/cc/fmtlib/BUILD.external
@@ -1,0 +1,12 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "fmt",
+    srcs = [
+        "src/format.cc",
+        "src/os.cc",
+    ],
+    hdrs = glob(["include/fmt/*.h"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Add a sample gtest test.

Use [fmtlib](https://github.com/fmtlib/fmt) instead of C++20 [`<format>`](https://en.cppreference.com/w/cpp/utility/format/format), given macOS does not seem to have this yet.