### PR TITLE
deps: Enable bazel version watch

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,14 @@
 {
-  extends: ["config:base", ":disableDependencyDashboard"],
-  ignorePaths: ["third_party/**"],
-  labels: ["dependencies"],
-  schedule: ["every weekend"],
+  extends: ['config:base', ':disableDependencyDashboard'],
+  ignorePaths: ['third_party/**'],
+  labels: ['dependencies'],
+  schedule: ['every weekend'],
+  regexManagers: [
+    {
+      fileMatch: '\\.bazelversion',
+      matchStrings: ['(?<currentValue>[0-9]+.[0-9]+.[0-9]+)'],
+      depNameTemplate: 'bazelbuild/bazel',
+      datasourceTemplate: 'github-releases'
+    }
+  ]
 }


### PR DESCRIPTION
Setup a regexManager to watch the version of Bazel and update it on new release.

Adapted the configuration from https://github.com/renovatebot/renovate/issues/6995.

I checked the syntax with [renovate-config-validator](https://github.com/renovatebot/renovate/blob/0b2a14e3a2c525e02edac21bfe9ad2e0bd27869c/lib/config-validator.ts):

```console
$ renovate-config-validator renovate.json5
 INFO: Validating renovate.json5
 INFO: Config validated successfully
```

At some point we should add this validation to CI.