### PR TITLE
feat: Add Swift example

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 build --cxxopt='-std=c++17'
 
 # Ensure rules_haskell picks up the correct toolchain on Mac.
-build --action_env=BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
+#build --action_env=BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
 
 build --java_language_version=17
 build --java_runtime_version=remotejdk_17

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,6 +15,12 @@ http_archive(
 )
 
 http_archive(
+    name = "build_bazel_rules_swift",
+    sha256 = "bf2861de6bf75115288468f340b0c4609cc99cc1ccc7668f0f71adfd853eedb3",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/1.7.1/rules_swift.1.7.1.tar.gz",
+)
+
+http_archive(
     name = "bazelruby_rules_ruby",
     patch_args = ["-p1"],
     patches = [
@@ -480,3 +486,11 @@ k8s_defaults(
     cluster = "satreix",
     kind = "deployment",
 )
+
+load("@build_bazel_rules_swift//swift:repositories.bzl", "swift_rules_dependencies")
+
+swift_rules_dependencies()
+
+load("@build_bazel_rules_swift//swift:extras.bzl", "swift_rules_extra_dependencies")
+
+swift_rules_extra_dependencies()

--- a/src/swift/hello_world/BUILD.bazel
+++ b/src/swift/hello_world/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary")
+load("//tools/test/binary:binary.bzl", "binary_test")
+
+swift_binary(
+    name = "hello_world",
+    srcs = ["main.swift"],
+)
+
+binary_test(
+    name = "hello_world_test",
+    binary = ":hello_world",
+)

--- a/src/swift/hello_world/main.swift
+++ b/src/swift/hello_world/main.swift
@@ -1,0 +1,7 @@
+var name = "World"
+
+if let nameIndex = CommandLine.arguments.firstIndex(of: "--name"), nameIndex + 1 < CommandLine.arguments.count {
+    name = CommandLine.arguments[nameIndex + 1]
+}
+
+print("Hello, \(name)!") 


### PR DESCRIPTION
This works by removing BAZEL_USE_CPP_ONLY_TOOLCHAIN=1, which breaks rules_haskell 🤨