### PR TITLE
feat: Add Objective-C example

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 build --cxxopt='-std=c++17'
 
 # Ensure rules_haskell picks up the correct toolchain on Mac.
-build --action_env=BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
+#build --action_env=BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
 
 build --java_language_version=17
 build --java_runtime_version=remotejdk_17

--- a/src/objc/hello_world/BUILD.bazel
+++ b/src/objc/hello_world/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "objc_library")
+
+objc_library(
+    name = "hello_world_lib",
+    srcs = ["main.m"],
+    sdk_frameworks = [
+        "Foundation",
+    ],
+)
+
+cc_binary(
+    name = "hello_world",
+    deps = [":hello_world_lib"],
+)

--- a/src/objc/hello_world/main.m
+++ b/src/objc/hello_world/main.m
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        NSLog(@"log message");
+        printf("Hello, World!\n");
+    }
+    return 0;
+}


### PR DESCRIPTION
This works by removing BAZEL_USE_CPP_ONLY_TOOLCHAIN=1, which breaks rules_haskell  🤨