### PR TITLE
test: Drop the build step

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,6 +31,3 @@ jobs:
 
       - name: Test
         run: ./bin/bazel test --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }} //...
-
-      - name: Build
-        run: ./bin/bazel build --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }} //...


### PR DESCRIPTION
Bazel test step will build everything in the target list as well, thus the build step is redundant.