### PR TITLE
test: Enable go passing test in xml reports

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,3 +6,5 @@ build --action_env=BAZEL_USE_CPP_ONLY_TOOLCHAIN=1
 build --java_runtime_version=remotejdk_11
 build --tool_java_language_version=11
 build --javacopt="--release 11"
+
+test --test_env=GO_TEST_WRAP_TESTV=1


### PR DESCRIPTION
rules_go [documents](https://github.com/bazelbuild/rules_go/blob/bfd31e0bebefa18b164719a83437d77772923292/go/private/rules/test.bzl#L447-L450):

>  the testbinary can be invoked with `-test.v` by setting `GO_TEST_WRAP_TESTV=1` in the test environment; this will result in the `XML_OUTPUT_FILE` containing more granular data.