### PR TITLE
deps: update rules_haskell to 0.16

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,20 +14,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform:
+        os:
           - macos-latest
           - ubuntu-latest
-    name: check - (${{ matrix.platform }})
-    runs-on: ${{ matrix.platform }}
+    name: check - (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
 
+      # https://github.com/tweag/rules_haskell/issues/704
+      - name: "[Haskell] Install required packages"
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -yy libtinfo5
+          sudo apt-get clean
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+
       # Ruby rules use host install still: https://github.com/bazelruby/rules_ruby/issues/112
-      - name: Setup Ruby
+      - name: "[Ruby] Install Ruby"
         uses: ruby/setup-ruby@v1.126.0
 
       - name: Install bazelisk
-        run: ./tools/ci/install_bazelisk.sh v1.14.0 ${{ matrix.platform }}
+        run: ./tools/ci/install_bazelisk.sh v1.14.0 ${{ matrix.os }}
 
       - name: Test
         run: ./bin/bazel test --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }} //...

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -154,9 +154,9 @@ http_archive(
 
 http_archive(
     name = "rules_haskell",
-    sha256 = "aba3c16015a2363b16e2f867bdc5c792fa71c68cb97d8fe95fddc41e409d6ba8",
-    strip_prefix = "rules_haskell-0.15",
-    urls = ["https://github.com/tweag/rules_haskell/archive/v0.15.tar.gz"],
+    sha256 = "2a07b55c30e526c07138c717b0343a07649e27008a873f2508ffab3074f3d4f3",
+    strip_prefix = "rules_haskell-0.16",
+    url = "https://github.com/tweag/rules_haskell/archive/refs/tags/v0.16.tar.gz",
 )
 
 http_archive(

--- a/third_party/haskell/stackage_snapshot.json
+++ b/third_party/haskell/stackage_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "__GENERATED_FILE_DO_NOT_MODIFY_MANUALLY": -1427712414,
-  "all-cabal-hashes": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-hashes/119eb802bf65f4f18407a09236de2d6a7b145605",
+  "__GENERATED_FILE_DO_NOT_MODIFY_MANUALLY": 1558209947,
+  "all-cabal-hashes": "https://raw.githubusercontent.com/commercialhaskell/all-cabal-hashes/866124eac5b9a0c1d5c64d3f71fbf1c5e9216c4d",
   "resolved": {
     "ansi-terminal": {"dependencies":["base","colour"],"location":{"type":"hackage","url":"https://hackage.haskell.org/package/ansi-terminal-0.11/ansi-terminal-0.11.tar.gz"},"name":"ansi-terminal","pinned":{"url":["https://hackage.haskell.org/package/ansi-terminal-0.11/ansi-terminal-0.11.tar.gz","https://s3.amazonaws.com/hackage.fpcomplete.com/package/ansi-terminal-0.11.tar.gz"],"sha256":"c6611b9e51add41db3f79eac30066c06b33a6ca2a09e586b4b361d7f98303793","cabal-sha256":"97470250c92aae14c4c810d7f664c532995ba8910e2ad797b29f22ad0d2d0194"},"version":"0.11"},
     "ansi-wl-pprint": {"dependencies":["ansi-terminal","base"],"location":{"type":"hackage","url":"https://hackage.haskell.org/package/ansi-wl-pprint-0.6.9/ansi-wl-pprint-0.6.9.tar.gz"},"name":"ansi-wl-pprint","pinned":{"url":["https://hackage.haskell.org/package/ansi-wl-pprint-0.6.9/ansi-wl-pprint-0.6.9.tar.gz","https://s3.amazonaws.com/hackage.fpcomplete.com/package/ansi-wl-pprint-0.6.9.tar.gz"],"sha256":"a7b2e8e7cd3f02f2954e8b17dc60a0ccd889f49e2068ebb15abfa1d42f7a4eac","cabal-sha256":"212144ea0623b1170807a4162db05d87f26cf10b334aeadd0edb377aba06a1ce"},"version":"0.6.9"},


### PR DESCRIPTION
Update rules_haskell to [0.16](https://github.com/tweag/rules_haskell/releases/tag/v0.16)