### PR TITLE
tools: Add bazel_use

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/bazelbuild/rules_go v0.38.1
 	github.com/google/cel-go v0.13.0
 	github.com/google/go-cmp v0.5.9
+	github.com/google/go-github/v50 v50.1.0
 	github.com/gosuri/uiprogress v0.0.1
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/zerolog/v2 v2.0.0-rc.3
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.3
@@ -29,6 +30,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/gosuri/uilive v0.0.4 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
@@ -37,9 +39,12 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
+	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
+	golang.org/x/oauth2 v0.5.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,9 +102,14 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-github/v50 v50.1.0 h1:hMUpkZjklC5GJ+c3GquSqOP/T4BNsB7XohaPhtMOzRk=
+github.com/google/go-github/v50 v50.1.0/go.mod h1:Ev4Tre8QoKiolvbpOSG3FIi4Mlon3S2Nt9W5JYqKiwA=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
@@ -207,6 +212,8 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.1.0 h1:MDRAIl0xIo9Io2xV565hzXHw3zVseKrJKodhohM5CjU=
+golang.org/x/crypto v0.1.0/go.mod h1:RecgLatLF4+eUMCP1PoPZQb+cVrJcOPbHkTkbkB9sbw=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -272,6 +279,8 @@ golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.5.0 h1:HuArIo48skDwlrvM3sEdHXElYslAMsf3KwRkkW4MC4s=
+golang.org/x/oauth2 v0.5.0/go.mod h1:9/XBHVqLaWO3/BRHs5jbpYCnOZVjj5V0ndyaAM7KB4I=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -392,6 +401,8 @@ google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
+google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/src/go/bazel_use/BUILD.bazel
+++ b/src/go/bazel_use/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "bazel_use_lib",
+    srcs = ["bazel_use.go"],
+    importpath = "github.com/satreix/everest/src/go/bazel_use",
+    visibility = ["//visibility:private"],
+    deps = ["@com_github_google_go_github_v50//github"],
+)
+
+go_binary(
+    name = "bazel_use",
+    embed = [":bazel_use_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/src/go/bazel_use/BUILD.bazel
+++ b/src/go/bazel_use/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "bazel_use_lib",
@@ -12,4 +12,14 @@ go_binary(
     name = "bazel_use",
     embed = [":bazel_use_lib"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "bazel_use_test",
+    srcs = ["bazel_use_test.go"],
+    embed = [":bazel_use_lib"],
+    deps = [
+        "@com_github_google_go_cmp//cmp",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/src/go/bazel_use/bazel_use.go
+++ b/src/go/bazel_use/bazel_use.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/google/go-github/v50/github"
+)
+
+var workspaceRE = regexp.MustCompile(`(?m)workspace\(\s*name = "(.+)",?\s*\)`)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintln(flag.CommandLine.Output(), "usage: bazel_use URI [REVISION]")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		fmt.Fprintln(flag.CommandLine.Output(), "error: missing URI")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	uri, err := url.Parse(flag.Arg(0))
+	if err != nil {
+		parts := strings.Split(flag.Arg(0), "/")
+		log.Printf("parts=%#v", parts)
+
+		var path string
+		if len(parts) == 1 {
+			path = fmt.Sprintf("/bazelbuild/%s", parts[0])
+		} else if len(parts) == 2 {
+			path = fmt.Sprintf("/%s/%s", parts[0], parts[1])
+		} else {
+			fmt.Fprintln(flag.CommandLine.Output(), "error: invalid URI %s", flag.Arg(0))
+			flag.Usage()
+			os.Exit(1)
+		}
+
+		uri = &url.URL{
+			Scheme: "https",
+			Host:   "github.com",
+			Path:   path,
+		}
+	}
+
+	if uri.Host != "github.com" {
+		log.Fatal("only github.com is supported (PR are welcome)")
+	}
+
+	pathParts := strings.Split(uri.Path, "/")
+	owner := pathParts[1]
+	repo := pathParts[2]
+
+	gh := github.NewClient(nil)
+
+	ctx := context.Background()
+	releases, _, err := gh.Repositories.ListReleases(ctx, owner, repo, &github.ListOptions{})
+	if err != nil {
+		log.Fatalf("github error: %s", err)
+	}
+
+	for _, release := range releases {
+		var name string
+		if cr, _, err := gh.Repositories.DownloadContents(ctx, owner, repo, "WORKSPACE", &github.RepositoryContentGetOptions{Ref: release.GetTagName()}); err == nil {
+			workspaceFile, err := io.ReadAll(cr)
+			if err != nil {
+				log.Fatal("workspace file read error")
+			}
+			name = parseWorkspaceName(string(workspaceFile))
+		}
+		if name == "" {
+			name = fmt.Sprintf("com_github_%s_%s", owner, repo)
+		}
+
+		downloadURL := fmt.Sprintf("https://github.com/bazelbuild/rules_cc/archive/%s.tar.gz", release.GetTagName())
+		stripPrefix := fmt.Sprintf("%s-%s", repo, strings.TrimPrefix(release.GetTagName(), "v"))
+
+		sha256, err := getSHA256(downloadURL)
+		if err != nil {
+			log.Fatalf("error: %#v", err)
+		}
+
+		if err := tpl.Execute(os.Stdout, &tplData{
+			Name:        name,
+			URL:         downloadURL,
+			Sha256:      sha256,
+			StripPrefix: stripPrefix,
+		}); err != nil {
+			log.Fatalf("template error: %s", err)
+		}
+		fmt.Fprintln(os.Stdout, "")
+		return
+	}
+
+	log.Fatalf("could not find a release for the project")
+}
+
+var tpl = template.Must(template.New("").Parse(`http_archive(
+    name = "{{.Name}}",
+    sha256 = "{{.Sha256}}",
+    strip_prefix = "{{.StripPrefix}}",
+    url = "{{.URL}}",
+)`))
+
+type tplData struct {
+	Name        string
+	URL         string
+	Sha256      string
+	StripPrefix string
+}
+
+func parseWorkspaceName(content string) string {
+	for _, match := range workspaceRE.FindAllStringSubmatch(content, -1) {
+		return match[1]
+	}
+	return ""
+}
+
+func getSHA256(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	hash := sha256.Sum256(body)
+	return fmt.Sprintf("%x", hash), nil
+}

--- a/src/go/bazel_use/bazel_use.go
+++ b/src/go/bazel_use/bazel_use.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -21,59 +22,36 @@ var workspaceRE = regexp.MustCompile(`(?m)workspace\(\s*name = "(.+)",?\s*\)`)
 
 func main() {
 	flag.Usage = func() {
-		fmt.Fprintln(flag.CommandLine.Output(), "usage: bazel_use URI [REVISION]")
+		fmt.Fprintln(flag.CommandLine.Output(), "usage: bazel_use URI")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
 
-	if flag.NArg() < 1 {
+	if flag.NArg() != 1 {
 		fmt.Fprintln(flag.CommandLine.Output(), "error: missing URI")
 		flag.Usage()
 		os.Exit(1)
 	}
 
-	uri, err := url.Parse(flag.Arg(0))
+	repo, err := parseRepository(flag.Arg(0))
 	if err != nil {
-		parts := strings.Split(flag.Arg(0), "/")
-		log.Printf("parts=%#v", parts)
-
-		var path string
-		if len(parts) == 1 {
-			path = fmt.Sprintf("/bazelbuild/%s", parts[0])
-		} else if len(parts) == 2 {
-			path = fmt.Sprintf("/%s/%s", parts[0], parts[1])
-		} else {
-			fmt.Fprintln(flag.CommandLine.Output(), "error: invalid URI %s", flag.Arg(0))
-			flag.Usage()
-			os.Exit(1)
-		}
-
-		uri = &url.URL{
-			Scheme: "https",
-			Host:   "github.com",
-			Path:   path,
-		}
+		fmt.Fprintf(flag.CommandLine.Output(), "error: invalid URI %s", flag.Arg(0))
+		flag.Usage()
+		os.Exit(1)
 	}
-
-	if uri.Host != "github.com" {
-		log.Fatal("only github.com is supported (PR are welcome)")
-	}
-
-	pathParts := strings.Split(uri.Path, "/")
-	owner := pathParts[1]
-	repo := pathParts[2]
 
 	gh := github.NewClient(nil)
 
 	ctx := context.Background()
-	releases, _, err := gh.Repositories.ListReleases(ctx, owner, repo, &github.ListOptions{})
+
+	releases, _, err := gh.Repositories.ListReleases(ctx, repo.Org, repo.Name, &github.ListOptions{})
 	if err != nil {
 		log.Fatalf("github error: %s", err)
 	}
 
 	for _, release := range releases {
 		var name string
-		if cr, _, err := gh.Repositories.DownloadContents(ctx, owner, repo, "WORKSPACE", &github.RepositoryContentGetOptions{Ref: release.GetTagName()}); err == nil {
+		if cr, _, err := gh.Repositories.DownloadContents(ctx, repo.Org, repo.Name, "WORKSPACE", &github.RepositoryContentGetOptions{Ref: release.GetTagName()}); err == nil {
 			workspaceFile, err := io.ReadAll(cr)
 			if err != nil {
 				log.Fatal("workspace file read error")
@@ -81,10 +59,10 @@ func main() {
 			name = parseWorkspaceName(string(workspaceFile))
 		}
 		if name == "" {
-			name = fmt.Sprintf("com_github_%s_%s", owner, repo)
+			name = fmt.Sprintf("com_github_%s_%s", repo.Org, repo.Name)
 		}
 
-		downloadURL := fmt.Sprintf("https://github.com/bazelbuild/rules_cc/archive/%s.tar.gz", release.GetTagName())
+		downloadURL := fmt.Sprintf("https://%s/%s/%s/archive/%s.tar.gz", repo.Host, repo.Org, repo.Name, release.GetTagName())
 		stripPrefix := fmt.Sprintf("%s-%s", repo, strings.TrimPrefix(release.GetTagName(), "v"))
 
 		sha256, err := getSHA256(downloadURL)
@@ -142,4 +120,52 @@ func getSHA256(url string) (string, error) {
 
 	hash := sha256.Sum256(body)
 	return fmt.Sprintf("%x", hash), nil
+}
+
+type repository struct {
+	Host string
+	Org  string
+	Name string
+}
+
+func parseRepository(s string) (*repository, error) {
+	uri, err := url.Parse(s)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("uri: %#v", uri)
+
+	if uri.Host == "" {
+		parts := strings.Split(s, "/")
+		fmt.Fprintf(os.Stderr, "parts=%#v\n", parts)
+
+		var path string
+		if len(parts) == 1 {
+			path = fmt.Sprintf("/bazelbuild/%s", parts[0])
+		} else if len(parts) == 2 {
+			path = fmt.Sprintf("/%s/%s", parts[0], parts[1])
+		} else {
+			return nil, fmt.Errorf("error: invalid URI: %s", s)
+		}
+
+		uri = &url.URL{
+			Scheme: "https",
+			Host:   "github.com",
+			Path:   path,
+		}
+	}
+
+	if uri.Host != "github.com" {
+		return nil, errors.New("only github.com is supported (PR are welcome)")
+	}
+
+	pathParts := strings.Split(uri.Path, "/")
+	repo := repository{
+		Host: uri.Host,
+		Org:  pathParts[1],
+		Name: pathParts[2],
+	}
+
+	return &repo, nil
 }

--- a/src/go/bazel_use/bazel_use_test.go
+++ b/src/go/bazel_use/bazel_use_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_parseWorkspaceName(t *testing.T) {
+	testCases := map[string]struct {
+		content string
+		want    string
+	}{
+		"one line": {
+			content: `workspace(name = "rules_cc")
+
+other rules
+`,
+			want: "rules_cc",
+		},
+		"multiple lines": {
+			content: `workspace(
+    name = "rules_cc",
+)
+
+other rules
+`,
+			want: "rules_cc",
+		},
+		"no name": {
+			content: `other rules
+`,
+			want: "",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := parseWorkspaceName(tc.content)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("parseWorkspaceName() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_getSHA256(t *testing.T) {
+	const want = "68e656b251e67e8358bef8483ab0d51c6619f3e7a1a9f0e75838d41ff368f728"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("hello, world!"))
+	}))
+	defer server.Close()
+
+	got, err := getSHA256(server.URL)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func Test_parseRepository(t *testing.T) {
+	testCases := map[string]struct {
+		input     string
+		want      *repository
+		wantError error
+	}{
+		"valid URL": {
+			input: "https://github.com/bazelbuild/bazel",
+			want: &repository{
+				Host: "github.com",
+				Org:  "bazelbuild",
+				Name: "bazel",
+			},
+		},
+		"invalid URL": {
+			input:     "https://example.com/foo/bar",
+			wantError: errors.New("only github.com is supported (PR are welcome)"),
+		},
+		"malformed URL": {
+			input:     "foo/bar/baz",
+			wantError: fmt.Errorf("error: invalid URI: %s", "foo/bar/baz"),
+		},
+		"bazel repo": {
+			input: "bar",
+			want: &repository{
+				Host: "github.com",
+				Org:  "bazelbuild",
+				Name: "bar",
+			},
+		},
+		"github repo": {
+			input: "foo/bar",
+			want: &repository{
+				Host: "github.com",
+				Org:  "foo",
+				Name: "bar",
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, err := parseRepository(tc.input)
+			if tc.wantError == nil && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.wantError != nil && (err == nil || err.Error() != tc.wantError.Error()) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("parseRepository() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/third_party/go/deps.bzl
+++ b/third_party/go/deps.bzl
@@ -219,6 +219,18 @@ def go_dependencies():
         version = "v0.5.9",
     )
     go_repository(
+        name = "com_github_google_go_github_v50",
+        importpath = "github.com/google/go-github/v50",
+        sum = "h1:hMUpkZjklC5GJ+c3GquSqOP/T4BNsB7XohaPhtMOzRk=",
+        version = "v50.1.0",
+    )
+    go_repository(
+        name = "com_github_google_go_querystring",
+        importpath = "github.com/google/go-querystring",
+        sum = "h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=",
+        version = "v1.1.0",
+    )
+    go_repository(
         name = "com_github_google_martian",
         importpath = "github.com/google/martian",
         sum = "h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=",


### PR DESCRIPTION
Add a `bazel_use` tool to print the `http_archive` for a given Github.com URL. This helps add a Bazel dependency on an external repository.