### PR TITLE
build: Enable bzlmod

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,5 @@
+common --enable_bzlmod
+
 build --cxxopt='-std=c++17'
 
 # Ensure rules_haskell picks up the correct toolchain on Mac.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,3 @@
+module(
+    name = "everest",
+)


### PR DESCRIPTION
Enable [bzlmod](https://docs.bazel.build/versions/5.0.0/bzlmod.html).