### PR TITLE
go: Strict go-mod-tidy

### DIFF
--- a/third_party/go/update.sh
+++ b/third_party/go/update.sh
@@ -1,7 +1,21 @@
 #!/bin/bash
 set -eufo pipefail
 
-bazel run @go_sdk//:bin/go -- mod tidy -e
+proto_packages=(
+    src/proto/bookstore/v1
+    src/proto/helloworld
+)
+
+for pkg in "${proto_packages[@]}"; do
+    echo "package $(basename "$pkg")" > "${pkg}/empty.go"
+done
+
+bazel run @go_sdk//:bin/go -- mod tidy
+
+for pkg in "${proto_packages[@]}"; do
+    rm -rf  "${pkg}/empty.go"
+done
+
 GO_DEPS_FILE="third_party/go/deps.bzl"
 bazel run //:gazelle -- update-repos \
     -build_file_proto_mode=disable_global \


### PR DESCRIPTION
Write empty go file to support `go mod tidy` and drop the `-s` option to fail fast.