### PR TITLE
build: Remove bazelisk setup

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,8 +34,6 @@ jobs:
       - name: "[Ruby] Install Ruby"
         uses: ruby/setup-ruby@v1.164.0
 
-      - uses: bazelbuild/setup-bazelisk@v2
-
       - name: Copy .bazelrc
         run: cp tools/ci/bazel.rc $HOME/.bazelrc
 


### PR DESCRIPTION
GitHub Actions includes Bazelisk by default as of https://github.com/actions/runner-images/pull/490.