### PR TITLE
ci: limit workflow permissions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,3 @@
-permissions:
-  contents: read
 name: CI
 
 on:
@@ -10,6 +8,9 @@ on:
     tags:
       - "*.*.*"
   pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   check:


### PR DESCRIPTION
Potential fix for [https://github.com/satreix/everest/security/code-scanning/1](https://github.com/satreix/everest/security/code-scanning/1)

To fix the problem, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the required permissions for the workflow. Based on the actions in the workflow, only `contents: read` is needed, as the workflow reads repository contents but does not modify them. If in the future additional write permissions are required (e.g., for issues or pull requests), they can be added explicitly.

The `permissions` block will be added just below the `name: CI` line, so it applies to all jobs in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
